### PR TITLE
Remove Classic-UI version override

### DIFF
--- a/classic/mx.ini
+++ b/classic/mx.ini
@@ -5,7 +5,7 @@
 
 [settings]
 ; example how to override a package version
-version-overrides =
+; version-overrides =
 ;    plone.staticresources==2.3.1
 
 ; example section to use packages from git


### PR DESCRIPTION
Sorry for that, we had a version override for Plone 6.1.2 ... now its outdated since 6.1.3