### PR TITLE
Update frontend Dockerfiles based on cookieplone, also copy pnpm-lock.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2025-10-30
+
+- Update frontend Dockerfiles to make sure packages are properly locked. @davisagli
+
 # 2025-10-05
 
 - Update to Plone 6.1.3, Volto 18.27.3, and Volto Light Theme 7.2.0. @mauritsvanrees @sneridagh @davisagli

--- a/frontend-seven/Dockerfile
+++ b/frontend-seven/Dockerfile
@@ -11,7 +11,7 @@ COPY --chown=node package.json /app/package.json.temp
 
 RUN --mount=type=cache,id=pnpm,target=/app/.pnpm-store,uid=1000 <<EOT
     set -e
-    python3 -c "import json; data = json.load(open('package.json.temp')); deps = data['dependencies']; data['dependencies'].update(deps); json.dump(data, open('package.json', 'w'), indent=2)"
+    python3 -c "import json; orig_data = json.load(open('package.json.temp')); orig_deps = orig_data['dependencies']; data = json.load(open('package.json')); data['dependencies'].update(orig_deps); json.dump(data, open('package.json', 'w'), indent=2)"
     rm package.json.temp
     (cd core && git fetch --depth 1 origin seven:seven && git checkout seven)
     pnpm install && make build-deps

--- a/frontend-volto/Dockerfile
+++ b/frontend-volto/Dockerfile
@@ -5,12 +5,16 @@ FROM plone/frontend-builder:${VOLTO_VERSION} AS builder
 COPY --chown=node packages/volto-demo /app/packages/volto-demo
 COPY --chown=node volto.config.js /app/
 COPY --chown=node package.json /app/package.json.temp
+COPY --chown=node mrs.developer.json /app/
+COPY --chown=node pnpm-workspace.yaml /app/
+COPY --chown=node pnpm-lock.yaml /app/
 
 RUN --mount=type=cache,id=pnpm,target=/app/.pnpm-store,uid=1000 <<EOT
     set -e
-    python3 -c "import json; data = json.load(open('package.json.temp')); deps = data['dependencies']; data['dependencies'].update(deps); json.dump(data, open('package.json', 'w'), indent=2)"
+    python3 -c "import json; orig_data = json.load(open('package.json.temp')); orig_deps = orig_data['dependencies']; data = json.load(open('package.json')); data['dependencies'].update(orig_deps); json.dump(data, open('package.json', 'w'), indent=2)"
     rm package.json.temp
-    pnpm install
+    pnpm dlx mrs-developer missdev --no-config --fetch-https
+    pnpm install && pnpm build:deps
     pnpm build
     pnpm install --prod
 EOT
@@ -23,3 +27,10 @@ LABEL maintainer="Plone Foundation <collective@plone.org>" \
       org.label-schema.vendor="Plone Foundation"
 
 COPY --from=builder /app/ /app/
+
+RUN <<EOT
+    set -e
+    npm i -g corepack@latest && corepack enable pnpm
+    corepack use pnpm@9.1.1
+    corepack prepare pnpm@9.1.1 --activate
+EOT

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -5,12 +5,16 @@ FROM plone/frontend-builder:${VOLTO_VERSION} AS builder
 COPY --chown=node packages/volto-demo /app/packages/volto-demo
 COPY --chown=node volto.config.js /app/
 COPY --chown=node package.json /app/package.json.temp
+COPY --chown=node mrs.developer.json /app/
+COPY --chown=node pnpm-workspace.yaml /app/
+COPY --chown=node pnpm-lock.yaml /app/
 
 RUN --mount=type=cache,id=pnpm,target=/app/.pnpm-store,uid=1000 <<EOT
     set -e
-    python3 -c "import json; data = json.load(open('package.json.temp')); deps = data['dependencies']; data['dependencies'].update(deps); json.dump(data, open('package.json', 'w'), indent=2)"
+    python3 -c "import json; orig_data = json.load(open('package.json.temp')); orig_deps = orig_data['dependencies']; data = json.load(open('package.json')); data['dependencies'].update(orig_deps); json.dump(data, open('package.json', 'w'), indent=2)"
     rm package.json.temp
-    pnpm install
+    pnpm dlx mrs-developer missdev --no-config --fetch-https
+    pnpm install && pnpm build:deps
     pnpm build
     pnpm install --prod
 EOT
@@ -23,3 +27,10 @@ LABEL maintainer="Plone Foundation <collective@plone.org>" \
       org.label-schema.vendor="Plone Foundation"
 
 COPY --from=builder /app/ /app/
+
+RUN <<EOT
+    set -e
+    npm i -g corepack@latest && corepack enable pnpm
+    corepack use pnpm@9.1.1
+    corepack prepare pnpm@9.1.1 --activate
+EOT


### PR DESCRIPTION
Two goals here:
- Make sure we're using the current best practice from cookieplone-templates
- Make sure the image has the same package versions that were locked outside the image

Note: frontend-seven doesn't have a pnpm-lock.yaml in the repository yet, we should add it